### PR TITLE
Enable specifying wasm features needed for uuid

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,14 @@ documentation = "https://docs.rs/blob-uuid"
 keywords = ["uuid", "blob", "base64"]
 edition = "2018"
 
-
 [dependencies]
 base64 = "0.10.0"
 uuid = { version = "0.8.1", features = ["v4"] }
+
+[features]
+default = []
+wasm-bindgen = ["uuid/wasm-bindgen"]
+stdweb = ["uuid/stdweb"]
 
 [workspace]
 members = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 use base64::DecodeError;
-use uuid::Error;
 
 pub use uuid::Uuid;
 


### PR DESCRIPTION
These features need to be exposed in order to properly configure `uuid` for compilation to WASM.

We might be able to avoid specifying these features by instructing users of the library to implement some kind of Cargo.toml overrides, but I couldn't figure out how to override features for a dep's dep.